### PR TITLE
Implement fix for chat search and remove mongo transactions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint && tsc --noEmit"
   },
   "dependencies": {
     "@apollo/client": "^3.11.3",

--- a/client/src/app/(main)/home/(main)/(connections)/all-friends/page.tsx
+++ b/client/src/app/(main)/home/(main)/(connections)/all-friends/page.tsx
@@ -12,7 +12,7 @@ import List from '@/components/common/List';
 import Search from '@/components/Search';
 
 export default function AllFriends() {
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
   const { data, error, refetch, fetchMore } = useFriends({
     variables: { search: debouncedSearch },
     fetchPolicy: 'cache-and-network',

--- a/client/src/app/(main)/home/(main)/(connections)/blocked/page.tsx
+++ b/client/src/app/(main)/home/(main)/(connections)/blocked/page.tsx
@@ -12,7 +12,7 @@ import List from '@/components/common/List';
 import Search from '@/components/Search';
 
 export default function Blocked() {
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
 
   const { data, loading, error, refetch, fetchMore } = useUserBlocks({
     fetchPolicy: 'cache-and-network',

--- a/client/src/app/(main)/home/(main)/(connections)/friend-requests/page.tsx
+++ b/client/src/app/(main)/home/(main)/(connections)/friend-requests/page.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export default function FriendRequests() {
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
 
   const { refetch: refetchIncoming, ...incomingRequestsQuery } =
     useFriendRequests({

--- a/client/src/app/(main)/home/(main)/(connections)/online-friends/page.tsx
+++ b/client/src/app/(main)/home/(main)/(connections)/online-friends/page.tsx
@@ -12,7 +12,7 @@ import useUserUpdated from '@/features/users/hooks/useUserUpdated';
 import Search from '@/components/Search';
 
 export default function OnlineFriends() {
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
 
   const { data, setData, error, refetch, fetchMore } = useFriends({
     variables: { status: 'online', search: debouncedSearch },

--- a/client/src/app/(main)/home/(main)/chat/[chatId]/_components/ChatHeader/index.tsx
+++ b/client/src/app/(main)/home/(main)/chat/[chatId]/_components/ChatHeader/index.tsx
@@ -32,7 +32,9 @@ export default function ChatHeader() {
   const { setMessageSearch } = useContext(ChatContext);
 
   useEffect(() => {
-    setMessageSearch(debouncedSearch);
+    if (debouncedSearch !== undefined) {
+      setMessageSearch(debouncedSearch);
+    }
   }, [setMessageSearch, debouncedSearch]);
 
   if (!meQuery.data || !chatQuery.data) {

--- a/client/src/app/(main)/home/(main)/chat/[chatId]/_components/ChatHeader/index.tsx
+++ b/client/src/app/(main)/home/(main)/chat/[chatId]/_components/ChatHeader/index.tsx
@@ -28,7 +28,7 @@ export default function ChatHeader() {
     if (error) throw error;
   }, [meQuery.error, chatQuery.error]);
 
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
   const { setMessageSearch } = useContext(ChatContext);
 
   useEffect(() => {

--- a/client/src/app/(main)/home/(main)/chat/[chatId]/_components/ChatUsersDisplay.tsx
+++ b/client/src/app/(main)/home/(main)/chat/[chatId]/_components/ChatUsersDisplay.tsx
@@ -18,7 +18,7 @@ export default function ChatUsersDisplay({
   className?: string;
 }) {
   const { chatId } = useContext(ChatContext);
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
 
   const { data, error, refetch, fetchMore } = useUsers({
     variables: chatId

--- a/client/src/app/(main)/home/_components/Sidebar/index.tsx
+++ b/client/src/app/(main)/home/_components/Sidebar/index.tsx
@@ -26,7 +26,7 @@ export default function Sidebar({
   className,
   isCollapsed = true,
 }: SidebarProps) {
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>();
 
   const { data, error, refetch, fetchMoreChats } = useMe({
     variables: { search: debouncedSearch },

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge';
 import { useDebounce } from 'use-debounce';
 
 interface SearchProps {
-  setDebouncedSearch: React.Dispatch<SetStateAction<string>>;
+  setDebouncedSearch: React.Dispatch<SetStateAction<string | undefined>>;
   placeholder?: string;
   className?: string;
 }

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -64,11 +64,14 @@ services:
     restart: always
     ports:
       - '27017:27017'
-    command: >
-      bash -c "
-        mongod --replSet rs0 --bind_ip_all &
-        sleep 5;
-        mongosh /docker-entrypoint-initdb.d/init-mongo.js;
-        tail -f /dev/null"
-    volumes:
-      - ../server/scripts/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=example
+    # command: >
+    #   bash -c "
+    #     mongod --replSet rs0 --bind_ip_all &
+    #     sleep 5;
+    #     mongosh /docker-entrypoint-initdb.d/init-mongo.js;
+    #     tail -f /dev/null"
+    # volumes:
+    #   - ../server/scripts/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -77,11 +77,14 @@ services:
     restart: always
     ports:
       - '27017:27017'
-    command: >
-      bash -c "
-        mongod --replSet rs0 --bind_ip_all &
-        sleep 5;
-        mongosh /docker-entrypoint-initdb.d/init-mongo.js;
-        tail -f /dev/null"
-    volumes:
-      - ../server/scripts/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=example
+    # command: >
+    #   bash -c "
+    #     mongod --replSet rs0 --bind_ip_all &
+    #     sleep 5;
+    #     mongosh /docker-entrypoint-initdb.d/init-mongo.js;
+    #     tail -f /dev/null"
+    # volumes:
+    #   - ../server/scripts/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js

--- a/docker/docker-compose.local-prod.yml
+++ b/docker/docker-compose.local-prod.yml
@@ -60,11 +60,14 @@ services:
     restart: always
     ports:
       - '27017:27017'
-    command: >
-      bash -c "
-        mongod --replSet rs0 --bind_ip_all &
-        sleep 5;
-        mongosh /docker-entrypoint-initdb.d/init-mongo.js;
-        tail -f /dev/null"
-    volumes:
-      - ../server/scripts/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=example
+    # command: >
+    #   bash -c "
+    #     mongod --replSet rs0 --bind_ip_all &
+    #     sleep 5;
+    #     mongosh /docker-entrypoint-initdb.d/init-mongo.js;
+    #     tail -f /dev/null"
+    # volumes:
+    #   - ../server/scripts/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -7,7 +7,7 @@
   },
   "extends": ["standard-with-typescript", "prettier"],
   "overrides": [{ "files": ["*.ts"] }],
-  "ignorePatterns": ["dist", "node_modules", "coverage"],
+  "ignorePatterns": ["dist", "node_modules", "coverage", "scripts"],
   "parserOptions": {
     "ecmaVersion": "latest"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "dev": "nodemon",
     "build": "tsc -p tsconfig.prod.json",
     "start": "node dist/app.js",
-    "lint": "npx eslint .",
+    "lint": "eslint . && tsc --noEmit",
     "test": "NODE_ENV=test npx jest --silent --color --runInBand --logHeapUsage --detectOpenHandles --coverage",
     "migrate:up": "ts-node scripts/migrate.ts up",
     "migrate:down": "ts-node scripts/migrate.ts down",

--- a/server/seeds/01_create_chats.ts
+++ b/server/seeds/01_create_chats.ts
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 
 import { NODE_ENV } from '../src/config/environment';
-import Chat from '../src/resources/chat/model';
+import { Chat } from '../src/resources';
 
 const getTimeAgo = (
   num: number,
@@ -22,7 +22,6 @@ const getTimeAgo = (
 const devData: { chats: any[]; chatsIds: number[] } = {
   chats: [
     ...Array.from({ length: 100 }, (_, i) => ({
-      name: `test${i}`,
       creator_id: i + 1,
       last_message_at: new Date(),
       last_message:

--- a/server/seeds/02_create_chat_users.ts
+++ b/server/seeds/02_create_chat_users.ts
@@ -6,15 +6,15 @@ import { ChatUser } from '../src/resources';
 
 const devData: { chatUsers: any[]; chatUsersIds: number[] } = {
   chatUsers: [
-    ...Array.from({ length: 10 }, (_, i) => ({
+    ...Array.from({ length: 50 }, (_, i) => ({
       user_id: i + 1,
       chat_id: i + 1,
     })),
-    ...Array.from({ length: 50 }, (_, i) => ({
+    ...Array.from({ length: 49 }, (_, i) => ({
       user_id: 1,
       chat_id: i + 2,
     })),
-    ...Array.from({ length: 50 }, (_, i) => ({
+    ...Array.from({ length: 49 }, (_, i) => ({
       user_id: i + 2,
       chat_id: 1,
     })),

--- a/server/seeds/03_create_messages.ts
+++ b/server/seeds/03_create_messages.ts
@@ -1,5 +1,5 @@
 import { NODE_ENV } from '../src/config/environment';
-import Message from '../src/resources/message/model';
+import { Message } from '../src/resources';
 
 const devData: { messages: any[]; messagesIds: string[] } = {
   messages: [

--- a/server/src/resources/message/mutations.ts
+++ b/server/src/resources/message/mutations.ts
@@ -3,7 +3,7 @@ import * as yup from 'yup';
 import bcrypt from 'bcrypt';
 import { GraphQLError } from 'graphql/error/GraphQLError';
 import { escape } from 'lodash';
-import { type ClientSession } from 'mongoose';
+// import { type ClientSession } from 'mongoose';
 
 import { Chat, ChatUser, Message } from '..';
 import type AuthService from '../../services/authService';
@@ -106,8 +106,8 @@ export const resolvers = {
       }
 
       const createMessageAndUpdateContext = async (
-        transaction: Transaction,
-        session: ClientSession
+        transaction: Transaction
+        // session: ClientSession
       ): Promise<IMessage & Required<{ _id: unknown }>> => {
         const newMessage = new Message({
           context_type: message.contextType,
@@ -118,7 +118,9 @@ export const resolvers = {
         const messageContext = message.contextType === 'chat' ? Chat : Chat;
 
         const [createdMessage] = await Promise.all([
-          newMessage.save({ session }),
+          newMessage.save({
+            // session
+          }),
           messageContext.update(
             { last_message: message.content, last_message_at: new Date() },
             { where: { id: message.contextId }, transaction }
@@ -186,15 +188,17 @@ export const resolvers = {
       }
 
       const updateMessageAndUpdateContext = async (
-        transaction: Transaction,
-        session: ClientSession
+        transaction: Transaction
+        // session: ClientSession
       ): Promise<IMessage & Required<{ _id: unknown }>> => {
         message.content = content;
         message.edited_at = new Date();
         const messageContext = message.context_type === 'chat' ? Chat : Chat;
 
         const [updatedMessage] = await Promise.all([
-          message.save({ session }),
+          message.save({
+            // session
+          }),
           messageContext.update(
             { last_message: content, last_message_at: new Date() },
             { where: { id: message.context_id }, transaction }

--- a/server/src/utils/api.ts
+++ b/server/src/utils/api.ts
@@ -1,14 +1,54 @@
-import mongoose, { type ClientSession } from 'mongoose';
+// import mongoose, { type ClientSession } from 'mongoose';
 import { type Transaction } from 'sequelize';
 import { GraphQLError } from 'graphql';
 
 import sequelize from '../config/sequelize';
 
+// interface TransactionParams {
+//   run: (
+//     sequelizeTransaction: Transaction,
+//     mongooseSession: ClientSession
+//   ) => Promise<any>;
+//   errorMessage: string;
+// }
+
+// export const transaction = async ({
+//   run,
+//   errorMessage,
+// }: TransactionParams): Promise<any> => {
+//   let sequelizeTransaction;
+//   let mongooseSession;
+//   try {
+//     [sequelizeTransaction, mongooseSession] = await Promise.all([
+//       sequelize.transaction(),
+//       mongoose.startSession(),
+//     ]);
+//     mongooseSession.startTransaction();
+
+//     const result = await run(sequelizeTransaction, mongooseSession);
+
+//     await Promise.all([
+//       sequelizeTransaction.commit(),
+//       mongooseSession.commitTransaction(),
+//     ]);
+//     return result;
+//   } catch (err: any) {
+//     await Promise.all([
+//       sequelizeTransaction?.rollback(),
+//       mongooseSession?.abortTransaction(),
+//     ]);
+
+//     const message = err.message ?? errorMessage;
+//     throw new GraphQLError(message as string, {
+//       extensions: { code: 'INTERNAL_SERVER_ERROR' },
+//     });
+//   } finally {
+//     await mongooseSession?.endSession();
+//   }
+// };
+
 interface TransactionParams {
-  run: (
-    sequelizeTransaction: Transaction,
-    mongooseSession: ClientSession
-  ) => Promise<any>;
+  run: (sequelizeTransaction: Transaction) => Promise<any>;
   errorMessage: string;
 }
 
@@ -17,32 +57,16 @@ export const transaction = async ({
   errorMessage,
 }: TransactionParams): Promise<any> => {
   let sequelizeTransaction;
-  let mongooseSession;
   try {
-    [sequelizeTransaction, mongooseSession] = await Promise.all([
-      sequelize.transaction(),
-      mongoose.startSession(),
-    ]);
-    mongooseSession.startTransaction();
-
-    const result = await run(sequelizeTransaction, mongooseSession);
-
-    await Promise.all([
-      sequelizeTransaction.commit(),
-      mongooseSession.commitTransaction(),
-    ]);
+    sequelizeTransaction = await sequelize.transaction();
+    const result = await run(sequelizeTransaction);
+    await sequelizeTransaction.commit();
     return result;
   } catch (err: any) {
-    await Promise.all([
-      sequelizeTransaction?.rollback(),
-      mongooseSession?.abortTransaction(),
-    ]);
-
+    await sequelizeTransaction?.rollback();
     const message = err.message ?? errorMessage;
     throw new GraphQLError(message as string, {
       extensions: { code: 'INTERNAL_SERVER_ERROR' },
     });
-  } finally {
-    await mongooseSession?.endSession();
   }
 };


### PR DESCRIPTION
The chat search used to search chats by name, but chats by default have a null name because a chat's name is determined on the client side using the names of the users in the chat. The chat search will now search chats by the names of its users. Mongo transactions require mongodb replica sets which cost money and so will be disabled